### PR TITLE
Enable video clip creation

### DIFF
--- a/README.md.txt
+++ b/README.md.txt
@@ -14,3 +14,12 @@
 cd backend
 npm install
 node server.js
+```
+3. En la segunda:
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+Ahora puedes subir un archivo de **audio** junto con imágenes o un archivo **video** para generar clips automáticos.


### PR DESCRIPTION
## Summary
- handle uploads of video files in the backend
- add `/process-video` endpoint to split video into clips
- support video uploads in the frontend UI and logic
- document how to run frontend and backend plus new feature

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686dfcfc8b508320bdebbe499370ba0f